### PR TITLE
GitHub Actions for Auto-deployment from 'production' Branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,17 +29,35 @@ jobs:
         with:
           push: true
           tags: nwplus/dinubot:latest
+      - 
+        name: Upload systemd service file
+        uses: actions/upload-artifact@v3
+        with:
+          name: dinubot-service-file
+          path: ./dinubot.service
 
   deploy:
     runs-on: self-hosted
     needs: dockerize
 
     steps:
+    - name: Download systemd service file
+      uses: actions/download-artifact@v3
+      with:
+        name: dinubot-service-file
+        path: .
+
     - name: Pull Docker image
       run: docker pull nwplus/dinubot:latest
 
-    - name: Run Docker container
+    - name: Copy systemd service file
+      run: sudo cp dinubot.service /etc/systemd/system/dinubot.service
+
+    - name: Reload systemd daemon
+      run: sudo systemctl daemon-reload
+
+    - name: Enable and start Dinubot service
       run: |
-        docker stop dinubot || true
-        docker rm dinubot || true
-        docker run -d -p 8000:8000 --name dinubot nwplus/dinubot:latest
+        sudo systemctl enable dinubot
+        sudo systemctl start dinubot
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Dockerize and Deploy
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  dockerize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: nwplus/dinubot:latest
+
+  deploy:
+    runs-on: self-hosted
+    needs: dockerize
+
+    steps:
+    - name: Pull Docker image
+      run: docker pull nwplus/dinubot:latest
+
+    - name: Run Docker container
+      run: |
+        docker stop dinubot || true
+        docker rm dinubot || true
+        docker run -d -p 8000:8000 --name dinubot nwplus/dinubot:latest

--- a/dinubot.service
+++ b/dinubot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=DinuBot, nwPlus's internal donut bot
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/home/ubuntu/DinuBot
+ExecStart=/usr/bin/docker compose up
+ExecStop=/usr/bin/docker compose down
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Restart=always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dinubot:
-    image: lsha0730/dinubot
+    image: nwplus/dinubot
     build: .
     env_file:
       - .env


### PR DESCRIPTION
On every push to the `production` branch, the workflow:
1. Pulls the latest changes from the `production` branch to a github-hosted VM, then builds it using docker. It's pushed to nwPlus' docker hub with image name `nwplus/dinubot`
2. Pulls the docker image on nwPlus' Oracle VM, then runs it. It runs it by registering it as a systemd service for extra resilience.

After pushing to production, check deployment status on the repo page under the 'Actions' tab