### PR TITLE
Inject Server Secret Files from Github Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,8 +53,17 @@ jobs:
     - name: Copy systemd service file
       run: sudo cp dinubot.service /etc/systemd/system/dinubot.service
 
+    - name: Create .env file from secret
+      run: echo "${{ secrets.ENV_FILE }}" > .env
+
+    - name: Create service_account.json file from secret
+      run: echo "${{ secrets.SERVICE_ACCOUNT_JSON }}" > service_account.json
+
     - name: Reload systemd daemon
       run: sudo systemctl daemon-reload
+
+    - name: Stop existing Dinubot service
+      run: sudo systemctl stop dinubot
 
     - name: Enable and start Dinubot service
       run: |

--- a/.github/workflows/refresh_secrets.yml
+++ b/.github/workflows/refresh_secrets.yml
@@ -1,0 +1,18 @@
+name: Refresh Secrets on Server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-service:
+    runs-on: self-hosted
+    steps:
+      - name: Create .env file from secret
+        run: echo "${{ secrets.ENV_FILE }}" > .env
+
+      - name: Create service_account.json file from secret
+        run: echo "${{ secrets.SERVICE_ACCOUNT_JSON }}" > service_account.json
+
+      - name: Restart Dinubot service
+        run: |
+          sudo systemctl restart dinubot


### PR DESCRIPTION
Code to support pulling `.env` and `service_account.json` from github secrets on deployment & on-demand