### PR TITLE
Dinubot Repeat Pairs Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -897,36 +897,6 @@ const updateMemberArrays = async () => {
 
 	await dinuBotData.update({ Members: membersData });
 
-	// // checks to see if anyone has left the channel, if so, reset both arrays
-	// for (const staticMember of staticArray) {
-	// 	if (!memberIDs.includes(staticMember)) {
-	// 		staticArray = [];
-	// 		dynamicArray = [];
-	// 	}
-	// }
-	// for (const dynamicMember of dynamicArray) {
-	// 	if (!memberIDs.includes(dynamicMember)) {
-	// 		staticArray = [];
-	// 		dynamicArray = [];
-	// 	}
-	// }
-
-	// shuffle memberIDs (incase members in channel changes)
-	// const shuffledMemberIDs = memberIDs.sort((a, b) => 0.5 - Math.random());
-
-	// for (const memberID of shuffledMemberIDs) {
-	// 	// if memberID is not in either arrays
-	// 	if (
-	// 		!(staticArray.includes(memberID) || dynamicArray.includes(memberID))
-	// 	) {
-	// 		// dynamicArray should > or = to staticArray
-	// 		if (staticArray.length == dynamicArray.length) {
-	// 			dynamicArray.push(memberID);
-	// 		} else {
-	// 			staticArray.push(memberID);
-	// 		}
-	// 	}
-	// }
 
 	// Grab data from Firebase to get members who opted out
 	documentSnapshot = await dinuBotData.get();
@@ -936,23 +906,6 @@ const updateMemberArrays = async () => {
 		.filter((member) => !member.optIn)
 		.map((member) => member.id);
 
-	// Remove opted-out members from dynamic and static arrays
-	// dynamicArray = dynamicArray.filter((member) => !optOut.includes(member));
-	// staticArray = staticArray.filter((member) => !optOut.includes(member));
-
-	// Rebalance static and dynamic arrays
-	// while (true) {
-	// 	const lengthDifference = dynamicArray.length - staticArray.length;
-	// 	if (lengthDifference === 0 || lengthDifference === 1) {
-	// 		break;
-	// 	}
-
-	// 	if (dynamicArray.length > staticArray.length) {
-	// 		staticArray.push(dynamicArray.pop());
-	// 	} else {
-	// 		dynamicArray.push(staticArray.pop());
-	// 	}
-	// }
 
 	membersData = membersData.map((member) => {
 		if (!member.optIn) {

--- a/index.js
+++ b/index.js
@@ -738,13 +738,9 @@ const createGroupChatAndSendMessage = async (userIds, messageText) => {
 	}
 };
 
-const pairMembers = async (staticArray, dynamicArray) => {
+const pairMembers = async (memberArray) => {
 	const channelID = process.env.channelID;
 	try {
-		const membersInfo = await slackClient.conversations.members({
-			channel: channelID,
-		});
-
 		let dinuBotData = db.doc("InternalProjects/DinuBot");
 		let documentSnapshot = await dinuBotData.get();
 		let membersData = documentSnapshot.data()["Members"] || { members: [] };
@@ -762,12 +758,11 @@ const pairMembers = async (staticArray, dynamicArray) => {
 					channel: channelID,
 					text: "No donuts possible, too many members are opted-out or blocked!",
 				});
-				break;
+				return;
 			}
 
-			[matchings, updatedDynamicArray] = createMatchings(
-				staticArray,
-				dynamicArray,
+			matchings = createMatchings(
+				memberArray,
 				2, // Specify group size
 			);
 
@@ -843,13 +838,12 @@ const pairMembers = async (staticArray, dynamicArray) => {
 				"Hello :wave: you're on a group donut ( ͡° ͜ʖ ͡°)!",
 			);
 		}
-		return [staticArray, updatedDynamicArray];
 	} catch (error) {
 		console.error("Error creating matching:", error);
 	}
 };
 
-const updateMemberArrays = async (staticArray, dynamicArray) => {
+const updateMemberArrays = async () => {
 	// Temporarily multiple channel ids for dev
 	const channelID = process.env.channelID;
 
@@ -875,6 +869,7 @@ const updateMemberArrays = async (staticArray, dynamicArray) => {
 		memberIDs.forEach((memberID) => {
 			membersData.members.push({
 				dontPair: [],
+				lastPairings: [],
 				id: memberID,
 				optIn: true,
 				optOutCycles: 0,
@@ -886,6 +881,7 @@ const updateMemberArrays = async (staticArray, dynamicArray) => {
 			if (!membersData.members.some((member) => member.id === memberID)) {
 				membersData.members.push({
 					dontPair: [],
+					lastPairings: [],
 					id: memberID,
 					optIn: true,
 					optOutCycles: 0,
@@ -901,36 +897,36 @@ const updateMemberArrays = async (staticArray, dynamicArray) => {
 
 	await dinuBotData.update({ Members: membersData });
 
-	// checks to see if anyone has left the channel, if so, reset both arrays
-	for (const staticMember of staticArray) {
-		if (!memberIDs.includes(staticMember)) {
-			staticArray = [];
-			dynamicArray = [];
-		}
-	}
-	for (const dynamicMember of dynamicArray) {
-		if (!memberIDs.includes(dynamicMember)) {
-			staticArray = [];
-			dynamicArray = [];
-		}
-	}
+	// // checks to see if anyone has left the channel, if so, reset both arrays
+	// for (const staticMember of staticArray) {
+	// 	if (!memberIDs.includes(staticMember)) {
+	// 		staticArray = [];
+	// 		dynamicArray = [];
+	// 	}
+	// }
+	// for (const dynamicMember of dynamicArray) {
+	// 	if (!memberIDs.includes(dynamicMember)) {
+	// 		staticArray = [];
+	// 		dynamicArray = [];
+	// 	}
+	// }
 
 	// shuffle memberIDs (incase members in channel changes)
-	const shuffledMemberIDs = memberIDs.sort((a, b) => 0.5 - Math.random());
+	// const shuffledMemberIDs = memberIDs.sort((a, b) => 0.5 - Math.random());
 
-	for (const memberID of shuffledMemberIDs) {
-		// if memberID is not in either arrays
-		if (
-			!(staticArray.includes(memberID) || dynamicArray.includes(memberID))
-		) {
-			// dynamicArray should > or = to staticArray
-			if (staticArray.length == dynamicArray.length) {
-				dynamicArray.push(memberID);
-			} else {
-				staticArray.push(memberID);
-			}
-		}
-	}
+	// for (const memberID of shuffledMemberIDs) {
+	// 	// if memberID is not in either arrays
+	// 	if (
+	// 		!(staticArray.includes(memberID) || dynamicArray.includes(memberID))
+	// 	) {
+	// 		// dynamicArray should > or = to staticArray
+	// 		if (staticArray.length == dynamicArray.length) {
+	// 			dynamicArray.push(memberID);
+	// 		} else {
+	// 			staticArray.push(memberID);
+	// 		}
+	// 	}
+	// }
 
 	// Grab data from Firebase to get members who opted out
 	documentSnapshot = await dinuBotData.get();
@@ -941,26 +937,26 @@ const updateMemberArrays = async (staticArray, dynamicArray) => {
 		.map((member) => member.id);
 
 	// Remove opted-out members from dynamic and static arrays
-	dynamicArray = dynamicArray.filter((member) => !optOut.includes(member));
-	staticArray = staticArray.filter((member) => !optOut.includes(member));
+	// dynamicArray = dynamicArray.filter((member) => !optOut.includes(member));
+	// staticArray = staticArray.filter((member) => !optOut.includes(member));
 
 	// Rebalance static and dynamic arrays
-	while (true) {
-		const lengthDifference = dynamicArray.length - staticArray.length;
-		if (lengthDifference === 0 || lengthDifference === 1) {
-			break;
-		}
+	// while (true) {
+	// 	const lengthDifference = dynamicArray.length - staticArray.length;
+	// 	if (lengthDifference === 0 || lengthDifference === 1) {
+	// 		break;
+	// 	}
 
-		if (dynamicArray.length > staticArray.length) {
-			staticArray.push(dynamicArray.pop());
-		} else {
-			dynamicArray.push(staticArray.pop());
-		}
-	}
+	// 	if (dynamicArray.length > staticArray.length) {
+	// 		staticArray.push(dynamicArray.pop());
+	// 	} else {
+	// 		dynamicArray.push(staticArray.pop());
+	// 	}
+	// }
 
 	membersData = membersData.map((member) => {
 		if (!member.optIn) {
-			member.optOutCycles += 1;
+			member.optOutCycles = (member.optOutCycles || 0) + 1;
 			if (member.optOutCycles >= 2) {
 				member.optIn = true;
 				member.optOutCycles = 0;
@@ -971,7 +967,8 @@ const updateMemberArrays = async (staticArray, dynamicArray) => {
 
 	await dinuBotData.update({ Members: { members: membersData } });
 
-	return [staticArray, dynamicArray];
+	const activeMemberIDs = memberIDs.filter(id => !optOut.includes(id));
+	return activeMemberIDs;
 };
 
 // Determines if it's time to send out new donuts (runs on interval)
@@ -1032,23 +1029,11 @@ const timeForDonutScheduler = async () => {
 				});
 
 				// get current member arrays
-				let currentStaticArray =
-					statusData["groupOfMembers"]["groupOfMembersStatic"];
-				let currentDynamicArray =
-					statusData["groupOfMembers"]["groupOfMembersDynamic"];
-				updateMemberArrays(
-					currentStaticArray,
-					currentDynamicArray,
-				).then((updatedArrays) => {
-					pairMembers(updatedArrays[0], updatedArrays[1]).then(
-						 (updatedArrays) => {
+				updateMemberArrays()
+				.then((optedInMemberIds) => {
+					pairMembers(optedInMemberIds).then(
+						 () => {
 							// pair people up
-							statusData["groupOfMembers"][
-								"groupOfMembersStatic"
-							] = updatedArrays[0]; // even if it's static, update it in case members join/leave
-							statusData["groupOfMembers"][
-								"groupOfMembersDynamic"
-							] = updatedArrays[1];
 							const nextDonutDate = new Date();
 							nextDonutDate.setDate(nextDonutDate.getDate() + 14);
 							statusData["schedule"]["nextDonut"]["sent"] = true; // set sent to True (is this necessary?)

--- a/index.js
+++ b/index.js
@@ -791,14 +791,40 @@ const pairMembers = async (staticArray, dynamicArray) => {
 						let memberBdontPair =
 							memberB?.dontPair?.map(decrypt) || [];
 
+						let memberALastPairings = memberA?.lastPairings?.map(decrypt) || [];
+						let memberBLastPairings = memberB?.lastPairings?.map(decrypt) || [];
+
 						return (
 							!memberAdontPair.includes(userB) &&
-							!memberBdontPair.includes(userA)
+							!memberBdontPair.includes(userA) && 
+							!memberALastPairings.includes(userB) &&
+							!memberBLastPairings.includes(userA)
 						);
 					});
 				});
 			});
 		}
+
+		for (const matching of matchings) {
+			for (let i = 0; i < matching.length; i++) {
+				const userA = matching[i];
+				const memberA = membersData.members.find((member) => member.id === userA);
+				if (!memberA.lastPairings) {
+					memberA.lastPairings = [];
+				}
+				for (let j = 0; j < matching.length; j++) {
+					if (i !== j) {
+						const userB = matching[j];
+						memberA.lastPairings.unshift(encrypt(userB));
+					}
+				}
+				while (memberA.lastPairings.length > 5) {
+					memberA.lastPairings.pop();
+				}
+			}	
+		}
+
+		await dinuBotData.update({ Members: membersData });
 
 		for (const matching of matchings) {
 			const displayNames = [];
@@ -955,7 +981,7 @@ const timeForDonutScheduler = async () => {
 		let statusData = documentSnapshot.data()["Status"];
 		convertTimeStamp(
 			statusData["schedule"]["nextDonut"]["dateToPairMembers"],
-		).then(function (nextDonutDay) {
+		).then( (nextDonutDay) => {
 			const nextDonutDate = nextDonutDay[0];
 			const nextDonutHour = nextDonutDay[1];
 			// Today
@@ -1013,9 +1039,9 @@ const timeForDonutScheduler = async () => {
 				updateMemberArrays(
 					currentStaticArray,
 					currentDynamicArray,
-				).then(function (updatedArrays) {
+				).then((updatedArrays) => {
 					pairMembers(updatedArrays[0], updatedArrays[1]).then(
-						function (updatedArrays) {
+						 (updatedArrays) => {
 							// pair people up
 							statusData["groupOfMembers"][
 								"groupOfMembersStatic"
@@ -1034,7 +1060,7 @@ const timeForDonutScheduler = async () => {
 							dinuBotData.firestore
 								.doc("InternalProjects/DinuBot")
 								.update({ Status: statusData });
-						},
+						}
 					);
 				});
 			} else {

--- a/src/matching.js
+++ b/src/matching.js
@@ -1,7 +1,7 @@
 // Updated createMatchings function to form groups of 4
-const createMatchings = (staticArray, dynamicArray, groupSize = 2) => {
-	const allMembers = [...staticArray, ...dynamicArray];
-	const shuffledMembers = shuffleArray(allMembers);
+const createMatchings = (memberArray, groupSize = 2) => {
+
+	const shuffledMembers = shuffleArray([...memberArray]);
 	const matchings = [];
 
 	// Form groups of the specified size
@@ -15,8 +15,7 @@ const createMatchings = (staticArray, dynamicArray, groupSize = 2) => {
 	}
 
 	// Return the matchings and updated dynamic array
-	const updatedDynamicArray = shuffledMembers;
-	return [matchings, updatedDynamicArray];
+	return matchings;
 };
 
 // Helper function to shuffle array


### PR DESCRIPTION
Updated the Dinubot algorithm to reduce repeat pairings. 
### Problem
The Dinubot algorithm did not work as intended - static and dynamic arrays served no purpose. They got combined together and shuffled (not following the implementation diagram). There was also no mechanism to check a member's previous pairings to prevent repeats. 

### Changes
- Got rid of static/dynamic arrays - replaced with a single array that is shuffled each week 
- added a lastPairings field to the database, which stores a member's last 5 donuts (encrypted ids)
- Dinubot checks a member's dontPair AND lastPairings array to make sure there are no conflicts before finalizing
- Fixed bug with optoutcycles - some member's had NaN in the database meaning they never get opted back in. Added a conditional check so this will be fixed next time dinubot runs. 
- Commented out old static and dynamic array logic in case we want to revert/use a different method. Let me know if these should be deleted. 

### Other Notes
- The next time dinubot runs, everyone will be initialized with an empty lastPairings array, meaning there is a chance for repeats. However, members shouldn't get paired with someone they have paired with in the last 5 cycles afterwards. 
- Also considered other algos like round robin and weighted randoms but it seemed too complicated for poor liitle Dinubot. Open to discussion.  
- Currently, the pairing function runs a max of 500 times before giving up. It is very unlikely that this will happen even with all the people in dontPair or optedout.
- Checking the last 5 members is hardcoded, this can be increased/decreased if desired. 